### PR TITLE
Fix missing libraries for gdb

### DIFF
--- a/generate_toolchain.sh
+++ b/generate_toolchain.sh
@@ -15,6 +15,8 @@ cp -r -L /opt/exodus/bundles/*/lib/${ARCH}-linux-gnu/* toolchain/lib/
 
 cp -r -L /opt/exodus/bundles/*/usr/lib/${ARCH}-linux-gnu/* toolchain/lib/
 
+cp -r -L /opt/exodus/bundles/*/usr/lib/*.so* toolchain/lib/
+
 cp -L \
       /lib/${ARCH}-linux-gnu/libresolv.so.2 \
       /lib/${ARCH}-linux-gnu/libnss_nisplus.so.2 \


### PR DESCRIPTION
### Problem summary

The GDB in the latest (v0.17) ldb_toolchain can't start properly.

```shell
❯ ./gdb
./gdb: error while loading shared libraries: libsource-highlight.so.4: cannot open shared object file: No such file or directory
```

### Cause

```
❯ ldd gdb
        linux-vdso.so.1 =>  (0x00007fff5f548000)
        libreadline.so.7 => /devel/ldb_toolchain_new/bin/./../lib/libreadline.so.7 (0x00007f51bae93000)
        libz.so.1 => /devel/ldb_toolchain_new/bin/./../lib/libz.so.1 (0x00007f51bac75000)
        libncurses.so.5 => /devel/ldb_toolchain_new/bin/./../lib/libncurses.so.5 (0x00007f51baa50000)
        libtinfo.so.5 => /devel/ldb_toolchain_new/bin/./../lib/libtinfo.so.5 (0x00007f51ba824000)
        libdl.so.2 => /devel/ldb_toolchain_new/bin/./../lib/libdl.so.2 (0x00007f51ba61f000)
        libpython3.6m.so.1.0 => /devel/ldb_toolchain_new/bin/./../lib/libpython3.6m.so.1.0 (0x00007f51b9f66000)
        libpthread.so.0 => /devel/ldb_toolchain_new/bin/./../lib/libpthread.so.0 (0x00007f51b9d44000)
        libm.so.6 => /devel/ldb_toolchain_new/bin/./../lib/libm.so.6 (0x00007f51b99a1000)
        libexpat.so.1 => /devel/ldb_toolchain_new/bin/./../lib/libexpat.so.1 (0x00007f51b976e000)
        liblzma.so.5 => /devel/ldb_toolchain_new/bin/./../lib/liblzma.so.5 (0x00007f51b9546000)
        libbabeltrace.so.1 => /devel/ldb_toolchain_new/bin/./../lib/libbabeltrace.so.1 (0x00007f51b9337000)
        libbabeltrace-ctf.so.1 => /devel/ldb_toolchain_new/bin/./../lib/libbabeltrace-ctf.so.1 (0x00007f51b90e4000)
        libipt.so.1 => /devel/ldb_toolchain_new/bin/./../lib/libipt.so.1 (0x00007f51b8ed1000)
        libmpfr.so.6 => /devel/ldb_toolchain_new/bin/./../lib/libmpfr.so.6 (0x00007f51b8c4d000)
        libsource-highlight.so.4 => not found
        libxxhash.so.0 => /devel/ldb_toolchain_new/bin/./../lib/libxxhash.so.0 (0x00007f51b8a43000)
        libstdc++.so.6 => /devel/ldb_toolchain_new/bin/./../lib/libstdc++.so.6 (0x00007f51b85e3000)
        libgcc_s.so.1 => /devel/ldb_toolchain_new/bin/./../lib/libgcc_s.so.1 (0x00007f51b83ca000)
        libc.so.6 => /devel/ldb_toolchain_new/bin/./../lib/libc.so.6 (0x00007f51b7fd9000)
        /devel/ldb_toolchain_new/lib/ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2 (0x00007f51bbb6b000)
        libutil.so.1 => /devel/ldb_toolchain_new/bin/./../lib/libutil.so.1 (0x00007f51b7dd5000)
        libglib-2.0.so.0 => /devel/ldb_toolchain_new/bin/./../lib/libglib-2.0.so.0 (0x00007f51b7ab1000)
        libdw.so.1 => /devel/ldb_toolchain_new/bin/./../lib/libdw.so.1 (0x00007f51b7865000)
        libelf.so.1 => /devel/ldb_toolchain_new/bin/./../lib/libelf.so.1 (0x00007f51b764a000)
        libuuid.so.1 => /devel/ldb_toolchain_new/bin/./../lib/libuuid.so.1 (0x00007f51b7442000)
        libgmp.so.10 => /devel/ldb_toolchain_new/bin/./../lib/libgmp.so.10 (0x00007f51b71bc000)
        libpcre.so.3 => /devel/ldb_toolchain_new/bin/./../lib/libpcre.so.3 (0x00007f51b6f4a000)
        libbz2.so.1.0 => /devel/ldb_toolchain_new/bin/./../lib/libbz2.so.1.0 (0x00007f51b6d39000)
```

The library `libsource-highlight.so.4` is missing.

In docker container, the library locates in `opt/exodus/bundles/*/usr/lib` but the script `generate_toolchain.sh` doesn't copy it.

```shell
root@f9574718a0fc:/opt/exodus/bundles/36f9fd1687042c293d769531cf35ae34900561c2d4f701e60a63295bad84b032/usr/lib# ls
aarch64-linux-gnu  libsource-highlight.so.4
```
